### PR TITLE
Initial cut at postgres support

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -14,6 +14,17 @@
     <basepom.shaded.main-class>com.hubspot.singularity.SingularityService</basepom.shaded.main-class>
   </properties>
 
+  <dependencyManagement>
+    <!-- TODO: Push up to hubspot basepom? -->
+    <dependencies>
+      <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
 
     <dependency>
@@ -406,6 +417,11 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -27,10 +27,10 @@ import com.hubspot.singularity.data.history.SingularityMappers.SingularityReques
 public abstract class HistoryJDBI implements GetHandle {
   private static final Logger LOG = LoggerFactory.getLogger(HistoryJDBI.class);
 
-  @SqlUpdate("INSERT INTO requestHistory (requestId, request, createdAt, requestState, user, message) VALUES (:requestId, :request, :createdAt, :requestState, :user, :message)")
+  @SqlUpdate("INSERT INTO requestHistory (requestId, request, createdAt, requestState, f_user, message) VALUES (:requestId, :request, :createdAt, :requestState, :user, :message)")
   abstract void insertRequestHistory(@Bind("requestId") String requestId, @Bind("request") byte[] request, @Bind("createdAt") Date createdAt, @Bind("requestState") String requestState, @Bind("user") String user, @Bind("message") String message);
 
-  @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
+  @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, f_user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
   abstract void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("message") String message, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
 
   @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt, purged) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt, false)")
@@ -47,19 +47,19 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlQuery("SELECT bytes FROM deployHistory WHERE requestId = :requestId AND deployId = :deployId")
   abstract byte[] getDeployHistoryForDeploy(@Bind("requestId") String requestId, @Bind("deployId") String deployId);
 
-  @SqlQuery("SELECT requestId, deployId, createdAt, user, message, deployStateAt, deployState FROM deployHistory WHERE requestId = :requestId ORDER BY createdAt DESC LIMIT :limitStart, :limitCount")
+  @SqlQuery("SELECT requestId, deployId, createdAt, f_user, message, deployStateAt, deployState FROM deployHistory WHERE requestId = :requestId ORDER BY createdAt DESC OFFSET :limitStart LIMIT :limitCount")
   abstract List<SingularityDeployHistory> getDeployHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
   abstract int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
 
-  @SqlQuery("SELECT request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount")
+  @SqlQuery("SELECT request, createdAt, requestState, f_user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> OFFSET :limitStart LIMIT :limitCount")
   abstract List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
 
-  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') LIMIT :limitStart, :limitCount")
+  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') OFFSET :limitStart LIMIT :limitCount")
   abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
@@ -171,14 +171,15 @@ public abstract class HistoryJDBI implements GetHandle {
     }
 
     if (limitStart.isPresent()) {
-      sqlBuilder.append(" LIMIT :limitStart, ");
+      sqlBuilder.append(" OFFSET :limitStart ");
       binds.put("limitStart", limitStart.get());
-    } else {
-      sqlBuilder.append(" LIMIT ");
     }
 
-    sqlBuilder.append(":limitCount");
-    binds.put("limitCount", limitCount);
+    if (limitCount != null ){
+      sqlBuilder.append(" LIMIT ");
+      sqlBuilder.append(":limitCount");
+      binds.put("limitCount", limitCount);
+    }
 
     final String sql = sqlBuilder.toString();
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
@@ -83,7 +83,7 @@ public class SingularityMappers {
     @Override
     public SingularityRequestHistory map(int index, ResultSet r, StatementContext ctx) throws SQLException {
       try {
-        return new SingularityRequestHistory(r.getTimestamp("createdAt").getTime(), Optional.fromNullable(r.getString("user")), RequestHistoryType.valueOf(r.getString("requestState")),
+        return new SingularityRequestHistory(r.getTimestamp("createdAt").getTime(), Optional.fromNullable(r.getString("f_user")), RequestHistoryType.valueOf(r.getString("requestState")),
             singularityRequestTranscoder.fromBytes(r.getBytes("request")), Optional.fromNullable(r.getString("message")));
       } catch (SingularityTranscoderException e) {
         throw new ResultSetException("Could not deserialize database result", e, ctx);
@@ -132,7 +132,7 @@ public class SingularityMappers {
     @Override
     public SingularityDeployHistory map(int index, ResultSet r, StatementContext ctx) throws SQLException {
       SingularityDeployMarker marker =
-          new SingularityDeployMarker(r.getString("requestId"), r.getString("deployId"), r.getTimestamp("createdAt").getTime(), Optional.fromNullable(r.getString("user")),
+          new SingularityDeployMarker(r.getString("requestId"), r.getString("deployId"), r.getTimestamp("createdAt").getTime(), Optional.fromNullable(r.getString("f_user")),
               Optional.fromNullable(r.getString("message")));
       SingularityDeployResult deployState =
           new SingularityDeployResult(DeployState.valueOf(r.getString("deployState")), Optional.<String>absent(), Optional.<SingularityLoadBalancerUpdate>absent(), Collections.<SingularityDeployFailure>emptyList(), r.getTimestamp("deployStateAt")

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -124,3 +124,11 @@ ALTER TABLE `taskHistory`
 ALTER TABLE `taskHistory`
   DROP KEY `startedAt2`,
   ADD KEY `startedAt3` (`startedAt`)
+
+
+--changeset mbell:17 dbms:mysql
+ALTER TABLE `requestHistory`
+  CHANGE COLUMN `user` `f_user` varchar(100) DEFAULT NULL;
+
+ALTER TABLE `deployHistory`
+CHANGE COLUMN `user` `f_user` varchar(100) DEFAULT NULL;

--- a/postgres/migrations.sql
+++ b/postgres/migrations.sql
@@ -1,0 +1,50 @@
+--liquibase formatted sql
+
+--changeset mbell:1 dbms:postgresql
+CREATE TABLE taskHistory (
+  taskId varchar(200) NOT NULL DEFAULT '',
+  requestId varchar(100) NOT NULL,
+  lastTaskStatus varchar(25) DEFAULT NULL,
+  updatedAt TIMESTAMP NOT NULL DEFAULT '1971-01-01 00:00:01',
+  bytes bytea NOT NULL,
+  runId VARCHAR(100) NULL,
+  deployId VARCHAR(100) NULL,
+  host VARCHAR(100) NULL,
+  startedAt TIMESTAMP NULL,
+  purged boolean not null default false,
+  PRIMARY KEY (taskId)
+);
+CREATE INDEX idx_task_requestId_2 ON taskHistory (requestId,updatedAt);
+CREATE INDEX idx_requestId_3 ON taskHistory (requestId,lastTaskStatus);
+CREATE INDEX idx_task_deploy ON taskHistory (requestId, deployId, startedAt);
+CREATE INDEX idx_task_run ON taskHistory(runId, requestId);
+CREATE INDEX idx_task_st ON taskHistory(requestId, startedAt);
+CREATE INDEX idx_lastStatus ON taskHistory(requestId, lastTaskStatus, startedAt);
+CREATE INDEX idx_host ON taskHistory(requestId, host, startedAt);
+CREATE INDEX idx_updated ON taskHistory(updatedAt, requestId);
+CREATE INDEX idx_purged ON taskHistory(requestId, purged, updatedAt);
+CREATE INDEX idx_task_stt ON taskHistory(startedAt);
+
+CREATE TABLE requestHistory (
+  requestId varchar(100) NOT NULL,
+  createdAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  requestState varchar(25) NOT NULL,
+  f_user varchar(100) DEFAULT NULL,
+  request bytea NOT NULL,
+  message VARCHAR(280) NULL,
+  PRIMARY KEY (requestId,createdAt)
+);
+
+
+CREATE TABLE deployHistory (
+  requestId varchar(100) NOT NULL,
+  deployId varchar(100) NOT NULL,
+  createdAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  f_user varchar(100) DEFAULT NULL,
+  deployStateAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  deployState varchar(25) NOT NULL,
+  bytes bytea NOT NULL,
+  message VARCHAR(280) NULL,
+  PRIMARY KEY (requestId,deployId)
+);
+CREATE INDEX idx_deploy_request ON deployHistory(requestId,createdAt);


### PR DESCRIPTION
- adds migrations (single changeset) for PG
- add changeset to MySQL to change user column to f_user (see below)
- adds dependency (managed) of PG jdbc driver.
- modifies HistoryJDBI in two core ways
* Change LIMIT (offset), (limit) to OFFSET (offset) LIMIT (limit) which is cross compatible and standard SQL
* Change user column to f_user
- modifies SingularityMappers to change user column to f_user

f_user:
- The reason for this change is "user" is a reserved word in Postgres. While one can quote the name in create table requests, it doesn't function properly unless all the DDL quotes the name (which uses " instead of `. Thus the easiest compatible option is to force a migration for everyone.
- An alternative would be to map a new interface HistoryJDBI with two implementations. I went for this initial implementation because I'm not terribly familiar with Guice and wanted to test this out.

Also not tackled:
* Tests. We use an embedded library of our own for that, It looks like most of your tests use h2 anyway. I think some of the integration tests use embedded mysql, and we could try emulating some of those.