### PR TITLE
Postgres support for JDBIHistory

### DIFF
--- a/Docs/about/how-it-works.md
+++ b/Docs/about/how-it-works.md
@@ -66,7 +66,7 @@ Slave placement can also be impacted by slave attributes. There are three scenar
 #### Singularity Scheduler Dependencies
 The Singularity scheduler uses ZooKeeper as a distributed replication log to maintain state and keep track of registered deployable items, the active deploys for these items and the running tasks that fulfill the deploys. As shown in the drawing, the same ZooKeeper quorum utilized by Mesos masters and slaves can be reused for Singularity.  
 
-Since ZooKeeper is not meant to handle large quantities of data, Singularity can optionally (and recommended for any real usage) utilize a MySQL database to periodically offload historical data from ZooKeeper and keep records of deployable item changes, deploy request history as well as the history of all launched tasks. 
+Since ZooKeeper is not meant to handle large quantities of data, Singularity can optionally (and recommended for any real usage) utilize a database (MySQL or PostgreSQL) to periodically offload historical data from ZooKeeper and keep records of deployable item changes, deploy request history as well as the history of all launched tasks. 
 
 In production environments Singularity should be run in high-availability mode by running multiple instances of the Singularity Scheduler component. As depicted in the drawing, only one instance is always active with all the other instances waiting in stand-by mode. While only one instance is registered for receiving resource offers, all instances can process API requests. Singularity uses ZooKeeper to perform leader election and maintain a single leader. Because of the ability for all instances to change state, Singularity internally uses queues which are consumed by the Singularity leader to make calls to Mesos.
 

--- a/Docs/features/task-search.md
+++ b/Docs/features/task-search.md
@@ -16,8 +16,8 @@ The above endpoint as well as `/api/history/request/{requestId}/tasks` now take 
 - `count`: Maximum number of items to return, defaults to 100 and has a maximum value of 1000
 - `page`: Page of items to view (e.g. page 1 is the first `count` items, page 2 is the next `count` items), defaults to 1
 
-For clusters using mysql that have a large number of tasks in the history, a relevant  configuration option of `taskHistoryQueryUsesZkFirst` has been added in the base Singularity Configuration. This option can be used to either prefer efficiency or exact ordering when searching through task history, it defaults to `false`.
+For clusters using a database that have a large number of tasks in the history, a relevant  configuration option of `taskHistoryQueryUsesZkFirst` has been added in the base Singularity Configuration. This option can be used to either prefer efficiency or exact ordering when searching through task history, it defaults to `false`.
 
-- When `false` the setting will prefer correct ordering. This may require multiple database calls, since Singularity needs to determine the overall order of items base on persisted (in mysql) and non-persisted (still in zookeeper) tasks. The overall search may be less efficient, but the ordering is guranteed to be correct.
+- When `false` the setting will prefer correct ordering. This may require multiple database calls, since Singularity needs to determine the overall order of items base on persisted (in the database) and non-persisted (still in zookeeper) tasks. The overall search may be less efficient, but the ordering is guranteed to be correct.
 
-- When `true` the setting will prefer efficiency. In this case, it will be assumed that all task histories in zookeeper (not yet persisted) come before those in mysql (persisted). This results in faster results and fewer queries, but ordering is not guaranteed to be correct between persisted and non-persisted items.
+- When `true` the setting will prefer efficiency. In this case, it will be assumed that all task histories in zookeeper (not yet persisted) come before those in the database (persisted). This results in faster results and fewer queries, but ordering is not guaranteed to be correct between persisted and non-persisted items.

--- a/Docs/getting-started/install.md
+++ b/Docs/getting-started/install.md
@@ -14,9 +14,9 @@ More info on how to manually set up a Zookeeper cluster lives [here](https://zoo
 
 For testing or local development purposes, a single-node cluster running on your local machine is fine. If using the [docker testing/development setup](../development/developing-with-docker.md), this will already be present.
 
-### 2. Set up MySQL (optional)
+### 2. Set up MySQL or PostgreSQL (optional)
 
-Singularity can be configured to move stale data from Zookeeper to MySQL after a configurable amount of time, which helps reduce strain on the cluster. If you're running Singularity in Production environment, MySQL is encouraged. See the [database reference](../reference/database.md) for help configuring the database.
+Singularity can be configured to move stale data from Zookeeper to a database after a configurable amount of time, which helps reduce strain on the cluster. If you're running Singularity in Production environment, enabling database support is encouraged. See the [database reference](../reference/database.md) for help configuring the database.
 
 ### 3. Set up a Mesos cluster
 
@@ -93,9 +93,9 @@ ui:
 
 Full configuration documentation lives here: [configuration.md](../reference/configuration.md)
 
-### 6. Run MySQL migrations (if necessary)
+### 6. Run database migrations (if necessary)
 
-If you're operating Singularity with MySQL, you first need to run a liquibase migration to create all appropriate tables: (this snippet assumes your Singularity configuration YAML exists as `singularity_config.yaml`)
+If you're operating Singularity with a database, you first need to run a liquibase migration to create all appropriate tables: (this snippet assumes your Singularity configuration YAML exists as `singularity_config.yaml`)
 
 `java -jar SingularityService/target/SingularityService-*-shaded.jar db migrate singularity_config.yaml --migrations mysql/migrations.sql`
 

--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -107,7 +107,7 @@ These settings are less likely to be changed, but were included in the configura
 | checkSchedulerEverySeconds | 5 | Runs scheduler checks (processes decommissions and pending queue) on this interval (these tasks also run when an offer is received) | long | 
 | checkWebhooksEveryMillis | 10000 (10 seconds) | Will check for and send new queued webhooks on this interval | long | 
 | cleanupEverySeconds | 5 | Will cleanup request, task, and other queues on this interval | long | 
-| persistHistoryEverySeconds | 3600 (1 hour) | Moves stale historical task data from ZooKeeper into MySQL, setting to 0 will disable history persistence | long |
+| persistHistoryEverySeconds | 3600 (1 hour) | Moves stale historical task data from ZooKeeper into the database, setting to 0 will disable history persistence | long |
 | saveStateEverySeconds | 60 | State about this Singularity instance is saved (available over API) on this interval | long |
 | checkJobsEveryMillis | 600000 (10 mins) | Check for jobs running longer than the expected time on this interval | long |
 | checkExpiringUserActionEveryMillis | 45000 | Check for expiring actions that should be expired on this interval | long |
@@ -130,7 +130,7 @@ These settings are less likely to be changed, but were included in the configura
 | Parameter | Default | Description | Type |
 |-----------|---------|-------------|------|
 | closeWaitSeconds | 5 | Will wait at least this many seconds when shutting down thread pools | long | 
-| compressLargeDataObjects | true | Will compress larger objects inside of ZooKeeper and MySQL | boolean |
+| compressLargeDataObjects | true | Will compress larger objects inside of ZooKeeper and the database | boolean |
 | maxHealthcheckResponseBodyBytes | 8192 | Number of bytes to save from healthcheck responses (displayed in UI) | int | 
 | maxQueuedUpdatesPerWebhook | 50 | Max number of updates to queue for a given webhook url, after which some webhooks will not be delivered | int | 
 | zookeeperAsyncTimeout | 5000 | Milliseconds for ZooKeeper timeout. Calls to ZooKeeper which take over this timeout will cause the operations to fail and Singularity to abort | long | 

--- a/Docs/reference/database.md
+++ b/Docs/reference/database.md
@@ -1,10 +1,10 @@
 ## Historical Data
 
-Singularity can optionally persist all task and deployment historical information into a MySQL database. This is useful because Mesos does not necessarily keep state forever, nor does it provide a deploy-focused interface for viewing that state. The Singularity API and web application will return historical information from both ZooKeeper and MySQL. Singularity will periodically dump stale state into MySQL.
+Singularity can optionally persist all task and deployment historical information into a MySQL or PostgreSQL database. This is useful because Mesos does not necessarily keep state forever, nor does it provide a deploy-focused interface for viewing that state. The Singularity API and web application will return historical information from both ZooKeeper and the database. Singularity will periodically dump stale state into the databaw.
 
 ### Configuration
 
-The `database` section of the Singularity configuration file must be populated in order for Singularity to persist task and deploy history information. Here's an example:
+The `database` section of the Singularity configuration file must be populated in order for Singularity to persist task and deploy history information. Here's an example using MySQL:
 
 ```
 database:
@@ -13,6 +13,9 @@ database:
   password: PASSWORD
   url: jdbc:mysql://HOSTNAME:3306/DB_NAME
 ```
+
+A PostgreSQL configuration would be similar, but use a driverClass of `org.postgresql.Driver` and an appropriate
+url - for example `jdbc:postgresql://HOSTNAME:5432/DB_NAME`
 
 ### Schema Changes
 
@@ -26,6 +29,8 @@ INFO  [2013-12-23 18:41:33,620] liquibase: Reading from singularity.DATABASECHAN
 INFO  [2013-12-23 18:41:33,668] liquibase: Reading from singularity.DATABASECHANGELOG
 1 change sets have not been applied to root@localhost@jdbc:mysql://localhost:3306/singularity
 ```
+
+**Note**: The appropriate migrations.sql differs depending on database flavor and is provided in the `postgres` or `mysql` directory of the Singularity distribution.
 
 To apply pending migrations, run the `db migrate` task:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Then simply run `docker-compose up` and it will start containers for...
  - [ZooKeeper](https://zookeeper.apache.org/doc/r3.4.6/zookeeperStarted.html) 
  - Java 7+
  - [MySQL](http://dev.mysql.com/usingmysql/get_started.html) (optional)
+ - PostgreSQL (optional)
 
 ##### Contact #####
 

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -14,6 +14,17 @@
     <basepom.shaded.main-class>com.hubspot.singularity.SingularityService</basepom.shaded.main-class>
   </properties>
 
+  <dependencyManagement>
+    <!-- TODO: Push up to hubspot basepom? -->
+    <dependencies>
+      <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
 
     <dependency>
@@ -406,6 +417,11 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -5,14 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.skife.jdbi.v2.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.OrderDirection;
 import com.hubspot.singularity.SingularityTaskIdHistory;
-
-import org.skife.jdbi.v2.Query;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // Common code for DB queries
 public abstract class AbstractHistoryJDBI implements HistoryJDBI {
@@ -106,14 +106,14 @@ public abstract class AbstractHistoryJDBI implements HistoryJDBI {
         }
 
         // NOTE: PG, MySQL are both compatible with OFFSET LIMIT syntax, while only MySQL understands LIMIT offset, limit.
-        if (limitStart.isPresent()) {
-            sqlBuilder.append(" OFFSET :limitStart ");
-            binds.put("limitStart", limitStart.get());
-        }
-
         if (limitCount != null ){
             sqlBuilder.append(" LIMIT :limitCount");
             binds.put("limitCount", limitCount);
+        }
+
+        if (limitStart.isPresent()) {
+            sqlBuilder.append(" OFFSET :limitStart ");
+            binds.put("limitStart", limitStart.get());
         }
 
         final String sql = sqlBuilder.toString();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -1,0 +1,153 @@
+package com.hubspot.singularity.data.history;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.hubspot.singularity.ExtendedTaskState;
+import com.hubspot.singularity.OrderDirection;
+import com.hubspot.singularity.SingularityTaskIdHistory;
+
+import org.skife.jdbi.v2.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Common code for DB queries
+public abstract class AbstractHistoryJDBI implements HistoryJDBI {
+    protected static final Logger LOG = LoggerFactory.getLogger(HistoryJDBI.class);
+
+    private static final String GET_TASK_ID_HISTORY_QUERY = "SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory";
+    private static final String GET_TASK_ID_HISTORY_COUNT_QUERY = "SELECT COUNT(*) FROM taskHistory";
+
+    protected void addWhereOrAnd(StringBuilder sqlBuilder, boolean shouldUseWhere) {
+        if (shouldUseWhere) {
+            sqlBuilder.append(" WHERE ");
+        } else {
+            sqlBuilder.append(" AND ");
+        }
+    }
+
+    protected void applyTaskIdHistoryBaseQuery(StringBuilder sqlBuilder, Map<String, Object> binds, Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
+                                             Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
+                                             Optional<Long> updatedAfter) {
+        if (requestId.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("requestId = :requestId");
+            binds.put("requestId", requestId.get());
+        }
+
+        if (deployId.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("deployId = :deployId");
+            binds.put("deployId", deployId.get());
+        }
+
+        if (runId.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("runId = :runId");
+            binds.put("runId", runId.get());
+        }
+
+        if (host.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("host = :host");
+            binds.put("host", host.get());
+        }
+
+        if (lastTaskStatus.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("lastTaskStatus = :lastTaskStatus");
+            binds.put("lastTaskStatus", lastTaskStatus.get().name());
+        }
+
+        if (startedBefore.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("startedAt < :startedBefore");
+            binds.put("startedBefore", new Date(startedBefore.get()));
+        }
+
+        if (startedAfter.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("startedAt > :startedAfter");
+            binds.put("startedAfter", new Date(startedAfter.get()));
+        }
+
+        if (updatedBefore.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("updatedAt < :updatedBefore");
+            binds.put("updatedBefore", new Date(updatedBefore.get()));
+        }
+
+        if (updatedAfter.isPresent()) {
+            addWhereOrAnd(sqlBuilder, binds.isEmpty());
+            sqlBuilder.append("updatedAt > :updatedAfter");
+            binds.put("updatedAfter", new Date(updatedAfter.get()));
+        }
+    }
+
+    @Override
+    public List<SingularityTaskIdHistory> getTaskIdHistory(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
+                                                           Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
+                                                           Optional<Long> updatedAfter, Optional<OrderDirection> orderDirection, Optional<Integer> limitStart, Integer limitCount) {
+
+        final Map<String, Object> binds = new HashMap<>();
+        final StringBuilder sqlBuilder = new StringBuilder(GET_TASK_ID_HISTORY_QUERY);
+
+        applyTaskIdHistoryBaseQuery(sqlBuilder, binds, requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
+
+        sqlBuilder.append(" ORDER BY startedAt ");
+        sqlBuilder.append(orderDirection.or(OrderDirection.DESC).name());
+
+        if (!requestId.isPresent()) {
+            sqlBuilder.append(", requestId ");
+            sqlBuilder.append(orderDirection.or(OrderDirection.DESC).name());
+        }
+
+        // NOTE: PG, MySQL are both compatible with OFFSET LIMIT syntax, while only MySQL understands LIMIT offset, limit.
+        if (limitStart.isPresent()) {
+            sqlBuilder.append(" OFFSET :limitStart ");
+            binds.put("limitStart", limitStart.get());
+        }
+
+        if (limitCount != null ){
+            sqlBuilder.append(" LIMIT :limitCount");
+            binds.put("limitCount", limitCount);
+        }
+
+        final String sql = sqlBuilder.toString();
+
+        LOG.trace("Generated sql for task search: {}, binds: {}", sql, binds);
+
+        final Query<SingularityTaskIdHistory> query = getHandle().createQuery(sql).mapTo(SingularityTaskIdHistory.class);
+        for (Map.Entry<String, Object> entry : binds.entrySet()) {
+            query.bind(entry.getKey(), entry.getValue());
+        }
+
+        return query.list();
+    }
+
+    @Override
+    public int getTaskIdHistoryCount(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
+                                     Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
+                                     Optional<Long> updatedAfter) {
+
+        final Map<String, Object> binds = new HashMap<>();
+        final StringBuilder sqlBuilder = new StringBuilder(GET_TASK_ID_HISTORY_COUNT_QUERY);
+
+        applyTaskIdHistoryBaseQuery(sqlBuilder, binds, requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
+
+        final String sql = sqlBuilder.toString();
+
+        LOG.trace("Generated sql for task search count: {}, binds: {}", sql, binds);
+
+        final Query<Integer> query = getHandle().createQuery(sql).mapTo(Integer.class);
+        for (Map.Entry<String, Object> entry : binds.entrySet()) {
+            query.bind(entry.getKey(), entry.getValue());
+        }
+
+        return query.first();
+    }
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -1,19 +1,7 @@
 package com.hubspot.singularity.data.history;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import org.skife.jdbi.v2.Query;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
-import org.skife.jdbi.v2.sqlobject.mixins.GetHandle;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.hubspot.singularity.ExtendedTaskState;
@@ -23,194 +11,41 @@ import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskIdHistory;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 
-@UseStringTemplate3StatementLocator
-public abstract class HistoryJDBI implements GetHandle {
-  private static final Logger LOG = LoggerFactory.getLogger(HistoryJDBI.class);
+import org.skife.jdbi.v2.sqlobject.mixins.GetHandle;
 
-  @SqlUpdate("INSERT INTO requestHistory (requestId, request, createdAt, requestState, user, message) VALUES (:requestId, :request, :createdAt, :requestState, :user, :message)")
-  abstract void insertRequestHistory(@Bind("requestId") String requestId, @Bind("request") byte[] request, @Bind("createdAt") Date createdAt, @Bind("requestState") String requestState, @Bind("user") String user, @Bind("message") String message);
+public interface HistoryJDBI extends GetHandle {
 
-  @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
-  abstract void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("message") String message, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
+  void insertRequestHistory(String requestId,byte[] request, Date createdAt, String requestState, String user, String message);
+  void insertDeployHistory(String requestId,String deployId, Date createdAt, String user, String message, Date deployStateAt, String deployState, byte[] bytes);
+  void insertTaskHistory(String requestId,String taskId, byte[] bytes,Date updatedAt,
+                         String lastTaskStatus, String runId,String deployId, String host,
+                         Date startedAt);
 
-  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt, purged) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt, false)")
-  abstract void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt,
-      @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId, @Bind("deployId") String deployId, @Bind("host") String host,
-      @Bind("startedAt") Date startedAt);
+  byte[] getTaskHistoryForTask(String taskId);
+  byte[] getTaskHistoryForTaskByRunId(String requestId, String runId);
 
-  @SqlQuery("SELECT bytes FROM taskHistory WHERE taskId = :taskId")
-  abstract byte[] getTaskHistoryForTask(@Bind("taskId") String taskId);
+  byte[] getDeployHistoryForDeploy(String requestId, String deployId);
+  List<SingularityDeployHistory> getDeployHistoryForRequest(String requestId, Integer limitStart, Integer limitCount);
+  int getDeployHistoryForRequestCount(String requestId);
 
-  @SqlQuery("SELECT bytes FROM taskHistory WHERE requestId = :requestId AND runId = :runId")
-  abstract byte[] getTaskHistoryForTaskByRunId(@Bind("requestId") String requestId, @Bind("runId") String runId);
+  List<SingularityRequestHistory> getRequestHistory(String requestId, String orderDirection, Integer limitStart, Integer limitCount);
+  int getRequestHistoryCount(String requestId);
+  List<String> getRequestHistoryLike(String requestIdLike, Integer limitStart,Integer limitCount);
+  List<SingularityRequestIdCount> getRequestIdCounts(Date updatedAt);
 
-  @SqlQuery("SELECT bytes FROM deployHistory WHERE requestId = :requestId AND deployId = :deployId")
-  abstract byte[] getDeployHistoryForDeploy(@Bind("requestId") String requestId, @Bind("deployId") String deployId);
+  Date getMinUpdatedAtWithLimitForRequest(String requestId, Integer limit);
 
-  @SqlQuery("SELECT requestId, deployId, createdAt, user, message, deployStateAt, deployState FROM deployHistory WHERE requestId = :requestId ORDER BY createdAt DESC LIMIT :limitStart, :limitCount")
-  abstract List<SingularityDeployHistory> getDeployHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+  void updateTaskHistoryNullBytesForRequestBefore(String requestId, Date updatedAtBefore, Integer purgeLimitPerQuery);
+  void deleteTaskHistoryForRequestBefore(String requestId,Date updatedAtBefore, Integer purgeLimitPerQuery);
+  List<String> getRequestIdsInTaskHistory();
+  int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date updatedAtBefore);
 
-  @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
-  abstract int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
+  void close();
 
-  @SqlQuery("SELECT request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount")
-  abstract List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
-
-  @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
-  abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
-
-  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') LIMIT :limitStart, :limitCount")
-  abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
-
-  @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
-  abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
-
-  @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
-  abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
-
-  @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
-  abstract void updateTaskHistoryNullBytesForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
-
-  @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
-  abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
-
-  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
-  abstract List<String> getRequestIdsInTaskHistory();
-
-  @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")
-  abstract int getUnpurgedTaskHistoryCountByRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
-
-
-  abstract void close();
-
-  private static final String GET_TASK_ID_HISTORY_QUERY = "SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory";
-  private static final String GET_TASK_ID_HISTORY_COUNT_QUERY = "SELECT COUNT(*) FROM taskHistory";
-
-
-  private void addWhereOrAnd(StringBuilder sqlBuilder, boolean shouldUseWhere) {
-    if (shouldUseWhere) {
-      sqlBuilder.append(" WHERE ");
-    } else {
-      sqlBuilder.append(" AND ");
-    }
-  }
-
-  private void applyTaskIdHistoryBaseQuery(StringBuilder sqlBuilder, Map<String, Object> binds, Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
-      Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
-      Optional<Long> updatedAfter) {
-    if (requestId.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("requestId = :requestId");
-      binds.put("requestId", requestId.get());
-    }
-
-    if (deployId.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("deployId = :deployId");
-      binds.put("deployId", deployId.get());
-    }
-
-    if (runId.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("runId = :runId");
-      binds.put("runId", runId.get());
-    }
-
-    if (host.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("host = :host");
-      binds.put("host", host.get());
-    }
-
-    if (lastTaskStatus.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("lastTaskStatus = :lastTaskStatus");
-      binds.put("lastTaskStatus", lastTaskStatus.get().name());
-    }
-
-    if (startedBefore.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("startedAt < :startedBefore");
-      binds.put("startedBefore", new Date(startedBefore.get()));
-    }
-
-    if (startedAfter.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("startedAt > :startedAfter");
-      binds.put("startedAfter", new Date(startedAfter.get()));
-    }
-
-    if (updatedBefore.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("updatedAt < :updatedBefore");
-      binds.put("updatedBefore", new Date(updatedBefore.get()));
-    }
-
-    if (updatedAfter.isPresent()) {
-      addWhereOrAnd(sqlBuilder, binds.isEmpty());
-      sqlBuilder.append("updatedAt > :updatedAfter");
-      binds.put("updatedAfter", new Date(updatedAfter.get()));
-    }
-  }
-
-    public List<SingularityTaskIdHistory> getTaskIdHistory(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
-      Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
-      Optional<Long> updatedAfter, Optional<OrderDirection> orderDirection, Optional<Integer> limitStart, Integer limitCount) {
-
-    final Map<String, Object> binds = new HashMap<>();
-    final StringBuilder sqlBuilder = new StringBuilder(GET_TASK_ID_HISTORY_QUERY);
-
-    applyTaskIdHistoryBaseQuery(sqlBuilder, binds, requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
-
-    sqlBuilder.append(" ORDER BY startedAt ");
-    sqlBuilder.append(orderDirection.or(OrderDirection.DESC).name());
-
-    if (!requestId.isPresent()) {
-      sqlBuilder.append(", requestId ");
-      sqlBuilder.append(orderDirection.or(OrderDirection.DESC).name());
-    }
-
-    if (limitStart.isPresent()) {
-      sqlBuilder.append(" LIMIT :limitStart, ");
-      binds.put("limitStart", limitStart.get());
-    } else {
-      sqlBuilder.append(" LIMIT ");
-    }
-
-    sqlBuilder.append(":limitCount");
-    binds.put("limitCount", limitCount);
-
-    final String sql = sqlBuilder.toString();
-
-    LOG.trace("Generated sql for task search: {}, binds: {}", sql, binds);
-
-    final Query<SingularityTaskIdHistory> query = getHandle().createQuery(sql).mapTo(SingularityTaskIdHistory.class);
-    for (Map.Entry<String, Object> entry : binds.entrySet()) {
-      query.bind(entry.getKey(), entry.getValue());
-    }
-
-    return query.list();
-  }
-
-  public int getTaskIdHistoryCount(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
-      Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
-      Optional<Long> updatedAfter) {
-
-    final Map<String, Object> binds = new HashMap<>();
-    final StringBuilder sqlBuilder = new StringBuilder(GET_TASK_ID_HISTORY_COUNT_QUERY);
-
-    applyTaskIdHistoryBaseQuery(sqlBuilder, binds, requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
-
-    final String sql = sqlBuilder.toString();
-
-    LOG.trace("Generated sql for task search count: {}, binds: {}", sql, binds);
-
-    final Query<Integer> query = getHandle().createQuery(sql).mapTo(Integer.class);
-    for (Map.Entry<String, Object> entry : binds.entrySet()) {
-      query.bind(entry.getKey(), entry.getValue());
-    }
-
-    return query.first();
-  }
-
+  List<SingularityTaskIdHistory> getTaskIdHistory(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
+                                                  Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
+                                                  Optional<Long> updatedAfter, Optional<OrderDirection> orderDirection, Optional<Integer> limitStart, Integer limitCount);
+  int getTaskIdHistoryCount(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host,
+                            Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter, Optional<Long> updatedBefore,
+                            Optional<Long> updatedAfter);
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -42,14 +42,26 @@ public class JDBIHistoryManager implements HistoryManager {
   @Timed
   public List<SingularityTaskIdHistory> getTaskIdHistory(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host, Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore,
       Optional<Long> startedAfter, Optional<Long> updatedBefore, Optional<Long> updatedAfter, Optional<OrderDirection> orderDirection, Optional<Integer> limitStart, Integer limitCount) {
-    return history.getTaskIdHistory(requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter, orderDirection, limitStart, limitCount);
+
+    List<SingularityTaskIdHistory> taskIdHistoryList =  history.getTaskIdHistory(requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter, orderDirection, limitStart, limitCount);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getTaskIdHistory {}", taskIdHistoryList);
+    }
+
+    return taskIdHistoryList;
   }
 
   @Override
   @Timed
   public int getTaskIdHistoryCount(Optional<String> requestId, Optional<String> deployId, Optional<String> runId, Optional<String> host, Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore,
        Optional<Long> startedAfter, Optional<Long> updatedBefore, Optional<Long> updatedAfter) {
-    return history.getTaskIdHistoryCount(requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
+
+    int count =  history.getTaskIdHistoryCount(requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getTaskIdHistoryCount {}", count);
+    }
+
+    return count;
   }
 
   private String getVarcharField(Optional<String> field, int maxLength) {
@@ -74,12 +86,20 @@ public class JDBIHistoryManager implements HistoryManager {
 
   @Override
   public void saveRequestHistoryUpdate(SingularityRequestHistory requestHistory) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("saveRequestHistoryUpdate {}",  requestHistory);
+    }
+
     history.insertRequestHistory(requestHistory.getRequest().getId(), singularityRequestTranscoder.toBytes(requestHistory.getRequest()), new Date(requestHistory.getCreatedAt()),
         requestHistory.getEventType().name(), getUserField(requestHistory.getUser()), getMessageField(requestHistory.getMessage()));
   }
 
   @Override
   public void saveDeployHistory(SingularityDeployHistory deployHistory) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("saveDeployHistory " + deployHistory);
+    }
+
     history.insertDeployHistory(deployHistory.getDeployMarker().getRequestId(),
         deployHistory.getDeployMarker().getDeployId(),
         new Date(deployHistory.getDeployMarker().getTimestamp()),
@@ -94,21 +114,36 @@ public class JDBIHistoryManager implements HistoryManager {
   public Optional<SingularityDeployHistory> getDeployHistory(String requestId, String deployId) {
     byte[] historyBytes = history.getDeployHistoryForDeploy(requestId, deployId);
 
-    if (historyBytes == null) {
-      return Optional.absent();
+    Optional<SingularityDeployHistory> historyOptional = Optional.absent();
+
+    if (historyBytes != null) {
+      historyOptional = Optional.of(deployHistoryTranscoder.fromBytes(historyBytes));
     }
 
-    return Optional.of(deployHistoryTranscoder.fromBytes(historyBytes));
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getDeployHistory {}",  historyOptional);
+    }
+
+
+    return  historyOptional;
   }
 
   @Override
   public List<SingularityDeployHistory> getDeployHistoryForRequest(String requestId, Integer limitStart, Integer limitCount) {
-    return history.getDeployHistoryForRequest(requestId, limitStart, limitCount);
+    List<SingularityDeployHistory> deployHistoryList = history.getDeployHistoryForRequest(requestId, limitStart, limitCount);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getDeployHistory {}", deployHistoryList);
+    }
+    return deployHistoryList;
   }
 
   @Override
   public int getDeployHistoryForRequestCount(String requestId) {
-    return history.getDeployHistoryForRequestCount(requestId);
+    int count =  history.getDeployHistoryForRequestCount(requestId);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getDeployHistoryForRequestCount {}", count);
+    }
+    return count;
   }
 
   private String getOrderDirection(Optional<OrderDirection> orderDirection) {
@@ -117,22 +152,37 @@ public class JDBIHistoryManager implements HistoryManager {
 
   @Override
   public List<SingularityRequestHistory> getRequestHistory(String requestId, Optional<OrderDirection> orderDirection, Integer limitStart, Integer limitCount) {
-    return history.getRequestHistory(requestId, getOrderDirection(orderDirection), limitStart, limitCount);
+    List<SingularityRequestHistory> singularityRequestHistoryList =  history.getRequestHistory(requestId, getOrderDirection(orderDirection), limitStart, limitCount);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getRequestHistory {}", singularityRequestHistoryList);
+    }
+    return singularityRequestHistoryList;
   }
 
   @Override
   public int getRequestHistoryCount(String requestId) {
+    int count = history.getRequestHistoryCount(requestId);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getRequestHistoryCount {}", count);
+    }
     return history.getRequestHistoryCount(requestId);
   }
 
   @Override
   public List<String> getRequestHistoryLike(String requestIdLike, Integer limitStart, Integer limitCount) {
-    return history.getRequestHistoryLike(requestIdLike, limitStart, limitCount);
+    List<String> list = history.getRequestHistoryLike(requestIdLike, limitStart, limitCount);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getRequestHistoryCountLike {}", list);
+    }
+    return list;
   }
 
   @Override
   public void saveTaskHistory(SingularityTaskHistory taskHistory) {
     if (history.getTaskHistoryForTask(taskHistory.getTask().getTaskId().getId()) != null) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("saveTaskHistory -- exists in DB {}", taskHistory);
+      }
       return;
     }
 
@@ -143,6 +193,10 @@ public class JDBIHistoryManager implements HistoryManager {
       lastTaskStatus = taskIdHistory.getLastTaskState().get().name();
     }
 
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("saveTaskHistory -- new! {}", taskHistory);
+    }
+
     history.insertTaskHistory(taskIdHistory.getTaskId().getRequestId(), taskIdHistory.getTaskId().getId(), taskHistoryTranscoder.toBytes(taskHistory), new Date(taskIdHistory.getUpdatedAt()),
         lastTaskStatus, taskHistory.getTask().getTaskRequest().getPendingTask().getRunId().orNull(), taskIdHistory.getTaskId().getDeployId(), taskIdHistory.getTaskId().getHost(),
         new Date(taskIdHistory.getTaskId().getStartedAt()));
@@ -151,38 +205,57 @@ public class JDBIHistoryManager implements HistoryManager {
   @Override
   public Optional<SingularityTaskHistory> getTaskHistory(String taskId) {
     byte[] historyBytes = history.getTaskHistoryForTask(taskId);
-
-    if (historyBytes == null || historyBytes.length == 0) {
-      return Optional.absent();
+    Optional<SingularityTaskHistory> taskHistoryOptional = Optional.absent();
+    if (historyBytes != null && historyBytes.length > 0) {
+      taskHistoryOptional = Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));;
+    }
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getTaskHistoryByTaskId {} ", taskHistoryOptional);
     }
 
-    return Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));
+    return taskHistoryOptional;
   }
 
   @Override
   public Optional<SingularityTaskHistory> getTaskHistoryByRunId(String requestId, String runId) {
     byte[] historyBytes = history.getTaskHistoryForTaskByRunId(requestId, runId);
 
-    if (historyBytes == null || historyBytes.length == 0) {
-      return Optional.absent();
+    Optional<SingularityTaskHistory> taskHistoryOptional = Optional.absent();
+    if (historyBytes != null && historyBytes.length > 0) {
+      taskHistoryOptional =  Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));;
     }
-
-    return Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getTaskHistoryByRequestAndRun {}",  taskHistoryOptional);
+    }
+    return taskHistoryOptional;
   }
 
   @Override
   public List<SingularityRequestIdCount> getRequestIdCounts(Date before) {
-    return history.getRequestIdCounts(before);
+    List<SingularityRequestIdCount> list  = history.getRequestIdCounts(before);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getRequestIdCountsUsingDateBefore {}", list);
+    }
+    return list;
   }
 
   @Override
   public List<String> getRequestIdsInTaskHistory() {
-    return history.getRequestIdsInTaskHistory();
+    List<String> list = history.getRequestIdsInTaskHistory();;
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getRequestIdsInTaskHistory {}", list);
+    }
+    return list;
   }
 
   @Override
   public int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date before) {
-    return history.getUnpurgedTaskHistoryCountByRequestBefore(requestId, before);
+    int count =  history.getUnpurgedTaskHistoryCountByRequestBefore(requestId, before);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("getUnpurgedTaskHistoryByRequestBeforeCount {}", count);
+    }
+
+    return count;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -45,7 +45,7 @@ public class JDBIHistoryManager implements HistoryManager {
 
     List<SingularityTaskIdHistory> taskIdHistoryList =  history.getTaskIdHistory(requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter, orderDirection, limitStart, limitCount);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getTaskIdHistory {}", taskIdHistoryList);
+      LOG.trace("getTaskIdHistory taskIdHistory {}", taskIdHistoryList);
     }
 
     return taskIdHistoryList;
@@ -87,7 +87,7 @@ public class JDBIHistoryManager implements HistoryManager {
   @Override
   public void saveRequestHistoryUpdate(SingularityRequestHistory requestHistory) {
     if (LOG.isTraceEnabled()) {
-      LOG.trace("saveRequestHistoryUpdate {}",  requestHistory);
+      LOG.trace("saveRequestHistoryUpdate requestHistory {}",  requestHistory);
     }
 
     history.insertRequestHistory(requestHistory.getRequest().getId(), singularityRequestTranscoder.toBytes(requestHistory.getRequest()), new Date(requestHistory.getCreatedAt()),
@@ -97,7 +97,7 @@ public class JDBIHistoryManager implements HistoryManager {
   @Override
   public void saveDeployHistory(SingularityDeployHistory deployHistory) {
     if (LOG.isTraceEnabled()) {
-      LOG.trace("saveDeployHistory " + deployHistory);
+      LOG.trace("saveDeployHistory {}", deployHistory);
     }
 
     history.insertDeployHistory(deployHistory.getDeployMarker().getRequestId(),
@@ -121,7 +121,8 @@ public class JDBIHistoryManager implements HistoryManager {
     }
 
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getDeployHistory {}",  historyOptional);
+      LOG.trace("getDeployHistory requestId {}, deployId {}, deployHistory {}",
+              requestId, deployId, historyOptional);
     }
 
 
@@ -132,7 +133,8 @@ public class JDBIHistoryManager implements HistoryManager {
   public List<SingularityDeployHistory> getDeployHistoryForRequest(String requestId, Integer limitStart, Integer limitCount) {
     List<SingularityDeployHistory> deployHistoryList = history.getDeployHistoryForRequest(requestId, limitStart, limitCount);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getDeployHistory {}", deployHistoryList);
+      LOG.trace("getDeployHistory requestId {}, limitStart {}, limitCount {} deployHistory {}",
+              requestId, limitStart, limitCount, deployHistoryList);
     }
     return deployHistoryList;
   }
@@ -141,7 +143,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public int getDeployHistoryForRequestCount(String requestId) {
     int count =  history.getDeployHistoryForRequestCount(requestId);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getDeployHistoryForRequestCount {}", count);
+      LOG.trace("getDeployHistoryForRequestCount requestId {}, count {}", requestId, count);
     }
     return count;
   }
@@ -154,7 +156,8 @@ public class JDBIHistoryManager implements HistoryManager {
   public List<SingularityRequestHistory> getRequestHistory(String requestId, Optional<OrderDirection> orderDirection, Integer limitStart, Integer limitCount) {
     List<SingularityRequestHistory> singularityRequestHistoryList =  history.getRequestHistory(requestId, getOrderDirection(orderDirection), limitStart, limitCount);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getRequestHistory {}", singularityRequestHistoryList);
+      LOG.trace("getRequestHistory requestId {}, orderDirection {}, limitStart {} , limitCount {}, requestHistory{}",
+              requestId, orderDirection, limitStart, limitCount, singularityRequestHistoryList);
     }
     return singularityRequestHistoryList;
   }
@@ -163,7 +166,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public int getRequestHistoryCount(String requestId) {
     int count = history.getRequestHistoryCount(requestId);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getRequestHistoryCount {}", count);
+      LOG.trace("getRequestHistoryCount requestId {}, count {}", requestId, count);
     }
     return history.getRequestHistoryCount(requestId);
   }
@@ -172,7 +175,8 @@ public class JDBIHistoryManager implements HistoryManager {
   public List<String> getRequestHistoryLike(String requestIdLike, Integer limitStart, Integer limitCount) {
     List<String> list = history.getRequestHistoryLike(requestIdLike, limitStart, limitCount);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getRequestHistoryCountLike {}", list);
+      LOG.trace("getRequestHistoryCountLike requestIdLike {}, limitStart {}, limitCount {}, requestIds {}",
+              requestIdLike, limitStart, limitCount, list);
     }
     return list;
   }
@@ -181,7 +185,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public void saveTaskHistory(SingularityTaskHistory taskHistory) {
     if (history.getTaskHistoryForTask(taskHistory.getTask().getTaskId().getId()) != null) {
       if (LOG.isTraceEnabled()) {
-        LOG.trace("saveTaskHistory -- exists in DB {}", taskHistory);
+        LOG.trace("saveTaskHistory -- existing taskHistory {}", taskHistory);
       }
       return;
     }
@@ -194,7 +198,7 @@ public class JDBIHistoryManager implements HistoryManager {
     }
 
     if (LOG.isTraceEnabled()) {
-      LOG.trace("saveTaskHistory -- new! {}", taskHistory);
+      LOG.trace("saveTaskHistory -- will insert taskHistory {}", taskHistory);
     }
 
     history.insertTaskHistory(taskIdHistory.getTaskId().getRequestId(), taskIdHistory.getTaskId().getId(), taskHistoryTranscoder.toBytes(taskHistory), new Date(taskIdHistory.getUpdatedAt()),
@@ -210,7 +214,7 @@ public class JDBIHistoryManager implements HistoryManager {
       taskHistoryOptional = Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));;
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getTaskHistoryByTaskId {} ", taskHistoryOptional);
+      LOG.trace("getTaskHistoryByTaskId taskId {}, taskHistory {} ", taskId, taskHistoryOptional);
     }
 
     return taskHistoryOptional;
@@ -225,7 +229,7 @@ public class JDBIHistoryManager implements HistoryManager {
       taskHistoryOptional =  Optional.of(taskHistoryTranscoder.fromBytes(historyBytes));;
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getTaskHistoryByRequestAndRun {}",  taskHistoryOptional);
+      LOG.trace("getTaskHistoryByRequestAndRun requestId {}, runId {}, taskHistory {}", requestId, runId, taskHistoryOptional);
     }
     return taskHistoryOptional;
   }
@@ -234,7 +238,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public List<SingularityRequestIdCount> getRequestIdCounts(Date before) {
     List<SingularityRequestIdCount> list  = history.getRequestIdCounts(before);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getRequestIdCountsUsingDateBefore {}", list);
+      LOG.trace("getRequestIdCountsUsingDateBefore before {}, requestIdCounts {}", before, list);
     }
     return list;
   }
@@ -243,7 +247,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public List<String> getRequestIdsInTaskHistory() {
     List<String> list = history.getRequestIdsInTaskHistory();;
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getRequestIdsInTaskHistory {}", list);
+      LOG.trace("getRequestIdsInTaskHistory requestIds {}", list);
     }
     return list;
   }
@@ -252,7 +256,7 @@ public class JDBIHistoryManager implements HistoryManager {
   public int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date before) {
     int count =  history.getUnpurgedTaskHistoryCountByRequestBefore(requestId, before);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("getUnpurgedTaskHistoryByRequestBeforeCount {}", count);
+      LOG.trace("getUnpurgedTaskHistoryByRequestBeforeCount requestId {}, before {}, count {}", requestId, before, count);
     }
 
     return count;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
@@ -1,0 +1,75 @@
+package com.hubspot.singularity.data.history;
+
+import java.util.Date;
+import java.util.List;
+
+import com.hubspot.singularity.SingularityDeployHistory;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.Define;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+
+@UseStringTemplate3StatementLocator
+public abstract class MySQLHistoryJDBI extends AbstractHistoryJDBI {
+
+  @SqlUpdate("INSERT INTO requestHistory (requestId, request, createdAt, requestState, user, message) VALUES (:requestId, :request, :createdAt, :requestState, :user, :message)")
+  public abstract void insertRequestHistory(@Bind("requestId") String requestId, @Bind("request") byte[] request, @Bind("createdAt") Date createdAt, @Bind("requestState") String requestState, @Bind("user") String user, @Bind("message") String message);
+
+  @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
+  public abstract void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("message") String message, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
+
+  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt, purged) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt, false)")
+  public abstract void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt,
+                                         @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId, @Bind("deployId") String deployId, @Bind("host") String host,
+                                         @Bind("startedAt") Date startedAt);
+
+  @SqlQuery("SELECT bytes FROM taskHistory WHERE taskId = :taskId")
+  public abstract byte[] getTaskHistoryForTask(@Bind("taskId") String taskId);
+
+  @SqlQuery("SELECT bytes FROM taskHistory WHERE requestId = :requestId AND runId = :runId")
+  public abstract byte[] getTaskHistoryForTaskByRunId(@Bind("requestId") String requestId, @Bind("runId") String runId);
+
+  @SqlQuery("SELECT bytes FROM deployHistory WHERE requestId = :requestId AND deployId = :deployId")
+  public abstract byte[] getDeployHistoryForDeploy(@Bind("requestId") String requestId, @Bind("deployId") String deployId);
+
+  @SqlQuery("SELECT requestId, deployId, createdAt, user, message, deployStateAt, deployState FROM deployHistory WHERE requestId = :requestId ORDER BY createdAt DESC LIMIT :limitStart,:limitCount")
+  public abstract List<SingularityDeployHistory> getDeployHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
+  public abstract int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
+
+  @SqlQuery("SELECT request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount")
+  public abstract List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
+  public abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
+
+  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') LIMIT :limitStart, :limitCount")
+  public abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
+  public abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
+
+  @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
+  public abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
+
+  @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
+  public abstract void updateTaskHistoryNullBytesForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
+
+  @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
+  public abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
+
+  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
+  public abstract List<String> getRequestIdsInTaskHistory();
+
+  @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")
+  public abstract int getUnpurgedTaskHistoryCountByRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
+
+
+  public abstract void close();
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
@@ -1,0 +1,75 @@
+package com.hubspot.singularity.data.history;
+
+import java.util.Date;
+import java.util.List;
+
+import com.hubspot.singularity.SingularityDeployHistory;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.Define;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+
+@UseStringTemplate3StatementLocator
+public abstract class PostgresHistoryJDBI extends AbstractHistoryJDBI {
+
+  @SqlUpdate("INSERT INTO requestHistory (requestId, request, createdAt, requestState, f_user, message) VALUES (:requestId, :request, :createdAt, :requestState, :user, :message)")
+  public abstract void insertRequestHistory(@Bind("requestId") String requestId, @Bind("request") byte[] request, @Bind("createdAt") Date createdAt, @Bind("requestState") String requestState, @Bind("user") String user, @Bind("message") String message);
+
+  @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, f_user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
+  public abstract void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("message") String message, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
+
+  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt, purged) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt, false)")
+  public abstract void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt,
+                                         @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId, @Bind("deployId") String deployId, @Bind("host") String host,
+                                         @Bind("startedAt") Date startedAt);
+
+  @SqlQuery("SELECT bytes FROM taskHistory WHERE taskId = :taskId")
+  public abstract byte[] getTaskHistoryForTask(@Bind("taskId") String taskId);
+
+  @SqlQuery("SELECT bytes FROM taskHistory WHERE requestId = :requestId AND runId = :runId")
+  public abstract byte[] getTaskHistoryForTaskByRunId(@Bind("requestId") String requestId, @Bind("runId") String runId);
+
+  @SqlQuery("SELECT bytes FROM deployHistory WHERE requestId = :requestId AND deployId = :deployId")
+  public abstract byte[] getDeployHistoryForDeploy(@Bind("requestId") String requestId, @Bind("deployId") String deployId);
+
+  @SqlQuery("SELECT requestId, deployId, createdAt, f_user, message, deployStateAt, deployState FROM deployHistory WHERE requestId = :requestId ORDER BY createdAt DESC OFFSET :limitStart LIMIT :limitCount")
+  public abstract List<SingularityDeployHistory> getDeployHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
+  public abstract int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
+
+  @SqlQuery("SELECT request, createdAt, requestState, f_user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> OFFSET :limitStart LIMIT :limitCount")
+  public abstract List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
+  public abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
+
+  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') OFFSET :limitStart LIMIT :limitCount")
+  public abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
+  public abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
+
+  @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
+  public abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
+
+  @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
+  public abstract void updateTaskHistoryNullBytesForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
+
+  @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
+  public abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
+
+  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
+  public abstract List<String> getRequestIdsInTaskHistory();
+
+  @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")
+  public abstract int getUnpurgedTaskHistoryCountByRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
+
+
+  public abstract void close();
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -75,7 +75,7 @@ public class SingularityHistoryModule extends AbstractModule {
   private void bindSpecificDatabase() {
     if (isPostgres(configuration)) {
       bind(HistoryJDBI.class).toProvider(PostgresHistoryJDBIProvider.class).in(Scopes.SINGLETON);
-    } else if (isMySQL(configuration)) {
+    } else if (isMySQL(configuration) || isH2(configuration)) {
       bind(HistoryJDBI.class).toProvider(MySQLHistoryJDBIProvider.class).in(Scopes.SINGLETON);
     } else {
       throw new IllegalStateException("Unknown driver class present " + configuration.get().getDriverClass());
@@ -174,6 +174,12 @@ public class SingularityHistoryModule extends AbstractModule {
   }
 
   // Convenience methods for determining which database is configured
+
+  static boolean isH2(Optional<DataSourceFactory> dataSourceFactoryOptional) {
+    return dataSourceFactoryOptional != null && dataSourceFactoryOptional.isPresent() &&
+            "org.h2.Driver".equals(dataSourceFactoryOptional.get().getDriverClass());
+  }
+
   static boolean isMySQL(Optional<DataSourceFactory> dataSourceFactoryOptional) {
     return dataSourceFactoryOptional != null && dataSourceFactoryOptional.isPresent() &&
             "com.mysql.jdbc.Driver".equals(dataSourceFactoryOptional.get().getDriverClass());

--- a/intro.md
+++ b/intro.md
@@ -53,6 +53,7 @@ Then simply run `docker-compose up` and it will start containers for...
  - [ZooKeeper](https://zookeeper.apache.org/doc/r3.4.6/zookeeperStarted.html) 
  - Java 8+
  - [MySQL](http://dev.mysql.com/usingmysql/get_started.html) (optional)
+ - PostgreSQL (optional)
 
 ##### Contact
 

--- a/postgres/migrations.sql
+++ b/postgres/migrations.sql
@@ -1,0 +1,50 @@
+--liquibase formatted sql
+
+--changeset mbell:1 dbms:postgresql
+CREATE TABLE taskHistory (
+  taskId varchar(200) NOT NULL DEFAULT '',
+  requestId varchar(100) NOT NULL,
+  lastTaskStatus varchar(25) DEFAULT NULL,
+  updatedAt TIMESTAMP NOT NULL DEFAULT '1971-01-01 00:00:01',
+  bytes bytea NOT NULL,
+  runId VARCHAR(100) NULL,
+  deployId VARCHAR(100) NULL,
+  host VARCHAR(100) NULL,
+  startedAt TIMESTAMP NULL,
+  purged boolean not null default false,
+  PRIMARY KEY (taskId)
+);
+CREATE INDEX idx_task_requestId_2 ON taskHistory (requestId,updatedAt);
+CREATE INDEX idx_requestId_3 ON taskHistory (requestId,lastTaskStatus);
+CREATE INDEX idx_task_deploy ON taskHistory (requestId, deployId, startedAt);
+CREATE INDEX idx_task_run ON taskHistory(runId, requestId);
+CREATE INDEX idx_task_st ON taskHistory(requestId, startedAt);
+CREATE INDEX idx_lastStatus ON taskHistory(requestId, lastTaskStatus, startedAt);
+CREATE INDEX idx_host ON taskHistory(requestId, host, startedAt);
+CREATE INDEX idx_updated ON taskHistory(updatedAt, requestId);
+CREATE INDEX idx_purged ON taskHistory(requestId, purged, updatedAt);
+CREATE INDEX idx_task_stt ON taskHistory(startedAt);
+
+CREATE TABLE requestHistory (
+  requestId varchar(100) NOT NULL,
+  createdAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  requestState varchar(25) NOT NULL,
+  f_user varchar(100) DEFAULT NULL,
+  request bytea NOT NULL,
+  message VARCHAR(280) NULL,
+  PRIMARY KEY (requestId,createdAt)
+);
+
+
+CREATE TABLE deployHistory (
+  requestId varchar(100) NOT NULL,
+  deployId varchar(100) NOT NULL,
+  createdAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  f_user varchar(100) DEFAULT NULL,
+  deployStateAt timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  deployState varchar(25) NOT NULL,
+  bytes bytea NOT NULL,
+  message VARCHAR(280) NULL,
+  PRIMARY KEY (requestId,deployId)
+);
+CREATE INDEX idx_deploy_request ON deployHistory(requestId,createdAt);


### PR DESCRIPTION
* refactors HistoryJDBI into an interface, with an abstract
base class for shared code (limit offset using standard SQL idiom)
and concrete subclasses for Postgres and MySQL.
* adds migrations (single changeset) for PG
* SingularityMappers can choose to use either f_user or user column - this is needed because Postgres considers user a reserved word.
* Modify SingularityHistoryModule to handle the new bindings
* JDBIHistoryManager - add debug logging at TRACE level.